### PR TITLE
Fetches and displays Flickr photos from album

### DIFF
--- a/app/api/gl-api/flickr/README.md
+++ b/app/api/gl-api/flickr/README.md
@@ -9,26 +9,7 @@ https://github.com/javascript-pro/core/issues/76
     description: "Retrieves a list of photo objects in the given album",
     result: [
         {
-            flickrId="xxxyyyzzz" // flickr's id
-            flickrURL="https://www.flickr.com/photos/listingslab/54528014218" // vital
-            title="trucks", // if any
-            description="big boys camping", // if any
-            time=100000000 // unix epock
-            meta="tags etc"
-            lat={0}
-            lng={0}
-            sizes={
-                orig: {
-                    src="https://" // use flickr as CDN
-                    width={1200}
-                    height={620}
-                },
-                small: {
-                    src="https://" // use flickr as CDN
-                    width={300}
-                    height={115}
-                }
-            }
+            
         },
     ],
 }

--- a/app/api/gl-api/flickr/README.md
+++ b/app/api/gl-api/flickr/README.md
@@ -1,0 +1,35 @@
+https://github.com/javascript-pro/core/issues/76
+
+/gl-api/flickr
+
+```javascript
+{
+    time: 1747815356331,
+    endpoint: "http://localhost:3000/api/gl-api/flickr?showablbum=xxx",
+    description: "Retrieves a list of photo objects in the given album",
+    result: [
+        {
+            flickrId="xxxyyyzzz" // flickr's id
+            flickrURL="https://www.flickr.com/photos/listingslab/54528014218" // vital
+            title="trucks", // if any
+            description="big boys camping", // if any
+            time=100000000 // unix epock
+            meta="tags etc"
+            lat={0}
+            lng={0}
+            sizes={
+                orig: {
+                    src="https://" // use flickr as CDN
+                    width={1200}
+                    height={620}
+                },
+                small: {
+                    src="https://" // use flickr as CDN
+                    width={300}
+                    height={115}
+                }
+            }
+        },
+    ],
+}
+```

--- a/app/api/gl-api/flickr/README.md
+++ b/app/api/gl-api/flickr/README.md
@@ -2,15 +2,4 @@ https://github.com/javascript-pro/core/issues/76
 
 /gl-api/flickr
 
-```javascript
-{
-    time: 1747815356331,
-    endpoint: "http://localhost:3000/api/gl-api/flickr?showablbum=xxx",
-    description: "Retrieves a list of photo objects in the given album",
-    result: [
-        {
-
-        },
-    ],
-}
-```
+album=72177720324245676

--- a/app/api/gl-api/flickr/README.md
+++ b/app/api/gl-api/flickr/README.md
@@ -9,7 +9,7 @@ https://github.com/javascript-pro/core/issues/76
     description: "Retrieves a list of photo objects in the given album",
     result: [
         {
-            
+
         },
     ],
 }

--- a/app/api/gl-api/flickr/route.ts
+++ b/app/api/gl-api/flickr/route.ts
@@ -1,5 +1,4 @@
 // core/app/api/gl-api/flickr/route.ts
-import config from '../config.json';
 import { NextRequest, NextResponse } from 'next/server';
 
 export type TFlickrPhotoSize = {
@@ -26,16 +25,27 @@ export type TFlickrPhoto = {
   };
 };
 
+const FLICKR_API = 'https://api.flickr.com/services/rest/';
+const flickrApiKey = process.env.FLICKR_KEY;
+const flickrUserId = process.env.FLICKR_USER;
+
 export async function GET(request: NextRequest) {
-  const { apibase } = config;
-  const description = 'Retrieves list of Flickr Photos in an album by album id';
   const { searchParams } = new URL(request.url);
   const album = searchParams.get('album');
+
+  if (!flickrApiKey || !flickrUserId) {
+    return NextResponse.json({
+      time: Date.now(),
+      endpoint: `/api/gl-api/flickr`,
+      status: 'warning',
+      message: 'Missing Flickr API credentials in .env file.',
+    });
+  }
 
   if (!album) {
     return NextResponse.json({
       time: Date.now(),
-      endpoint: `${apibase}/flickr`,
+      endpoint: `/api/gl-api/flickr`,
       status: 'warning',
       message:
         'You need to specify a valid flickr album id in the query string like this ?album=72177720324245676',
@@ -44,33 +54,54 @@ export async function GET(request: NextRequest) {
 
   let status: 'success' | 'warning' = 'success';
   let message = 'All Good';
+  let result: TFlickrPhoto[] = [];
 
-  // Simulate a valid album check (you’ll replace this with real Flickr logic)
   try {
-    if (!album.startsWith('721')) {
-      throw new Error('Invalid album ID format.');
+    const flickrRes = await fetch(
+      `${FLICKR_API}?method=flickr.photosets.getPhotos&api_key=${flickrApiKey}&photoset_id=${album}&user_id=${flickrUserId}&format=json&nojsoncallback=1&extras=description,date_taken,geo,tags,url_o,url_h,url_c,url_n`
+    );
+
+    const data = await flickrRes.json();
+
+    if (data.stat !== 'ok') {
+      throw new Error(data.message || 'Flickr API returned an error');
     }
 
-    // TODO: Call Flickr API here
+    result = data.photoset.photo.map((photo: any): TFlickrPhoto => {
+      return {
+        flickrId: photo.id,
+        flickrUrl: `https://www.flickr.com/photos/${flickrUserId}/${photo.id}`,
+        title: photo.title,
+        description: photo.description?._content || '',
+        time: new Date(photo.datetaken).getTime(),
+        lat: parseFloat(photo.latitude) || null,
+        lng: parseFloat(photo.longitude) || null,
+        meta: { tags: photo.tags?.split(' ') || [] },
+        sizes: {
+          orig: photo.url_o
+            ? { src: photo.url_o, width: parseInt(photo.width_o), height: parseInt(photo.height_o) }
+            : undefined,
+          large: photo.url_h
+            ? { src: photo.url_h, width: parseInt(photo.width_h), height: parseInt(photo.height_h) }
+            : undefined,
+          medium: photo.url_c
+            ? { src: photo.url_c, width: parseInt(photo.width_c), height: parseInt(photo.height_c) }
+            : undefined,
+          small: photo.url_n
+            ? { src: photo.url_n, width: parseInt(photo.width_n), height: parseInt(photo.height_n) }
+            : undefined,
+        },
+      };
+    });
   } catch (err: any) {
     status = 'warning';
     message = err.message || 'Unknown error during Flickr album lookup.';
-    return NextResponse.json({
-      time: Date.now(),
-      endpoint: `${apibase}/flickr`,
-      album,
-      status,
-      message,
-    });
+    result = [];
   }
-
-  const result: TFlickrPhoto[] = [
-
-  ];
 
   return NextResponse.json({
     time: Date.now(),
-    endpoint: `${apibase}/flickr?album=${album}`,
+    endpoint: `/api/gl-api/flickr?album=${album}`,
     album,
     status,
     message,

--- a/app/api/gl-api/flickr/route.ts
+++ b/app/api/gl-api/flickr/route.ts
@@ -2,9 +2,14 @@
 import config from '../config.json';
 import { NextRequest, NextResponse } from 'next/server';
 
+export type TFlickrPhotoSize = {
+  src: string;
+  width: number;
+  height: number;
+};
 
 export type TFlickrPhoto = {
-  id: string;
+  id?: string;
   flickrId: string;
   flickrUrl: string;
   title?: string;
@@ -12,71 +17,79 @@ export type TFlickrPhoto = {
   lat?: number | null;
   lng?: number | null;
   time?: number;
-  meta?: any;
+  meta?: Record<string, any>;
   sizes?: {
-    orig?: {
-      src: string;
-      width: number;
-      height: number;
-    };
-    small?: {
-      src: string;
-      width: number;
-      height: number;
-    };
-    medium?: {
-      src: string;
-      width: number;
-      height: number;
-    };
-    large?: {
-      src: string;
-      width: number;
-      height: number;
-    };
+    orig?: TFlickrPhotoSize;
+    small?: TFlickrPhotoSize;
+    medium?: TFlickrPhotoSize;
+    large?: TFlickrPhotoSize;
   };
 };
 
 export async function GET(request: NextRequest) {
   const { apibase } = config;
   const description = 'Retrieves list of Flickr Photos in an album by album id';
-  
-  let error = false;
-  let message = "All Good";
+  const { searchParams } = new URL(request.url);
+  const album = searchParams.get('album');
 
-  if (error){
+  if (!album) {
     return NextResponse.json({
-    time: Date.now(),
-    endpoint: `${apibase}/flickr`,
-    description,
-    status: 'error',
-    message,
-  });
+      time: Date.now(),
+      endpoint: `${apibase}/flickr`,
+      status: 'warning',
+      message: 'You need to specify a flickr album id in the query string like this ?album=7210000000',
+    });
   }
+
+  let status: 'success' | 'warning' = 'success';
+  let message = 'All Good';
+
+  // Simulate a valid album check (you’ll replace this with real Flickr logic)
+  try {
+    if (!album.startsWith('721')) {
+      throw new Error('Invalid album ID format.');
+    }
+
+    // TODO: Call Flickr API here
+
+  } catch (err: any) {
+    status = 'warning';
+    message = err.message || 'Unknown error during Flickr album lookup.';
+    return NextResponse.json({
+      time: Date.now(),
+      endpoint: `${apibase}/flickr`,
+      album,
+      status,
+      message,
+    });
+  }
+
+  const result: TFlickrPhoto[] = [
+    {
+      flickrId: '54528014218',
+      flickrUrl: 'https://www.flickr.com/photos/listingslab/54528014218',
+      title: 'Trucks',
+      description: 'Big boys camping',
+      time: Date.now(),
+      lat: 0,
+      lng: 0,
+      meta: { tags: ['camping', 'trucks'] },
+      sizes: {
+        orig: {
+          src: 'https://live.staticflickr.com/.../54528014218_o.jpg',
+          width: 1200,
+          height: 620,
+        },
+      },
+    },
+  ];
 
   return NextResponse.json({
     time: Date.now(),
-    endpoint: `${apibase}/flickr`,
-    description,
-    status: 'success',
-    result: [
-      {
-        flickrId: "54528014218",
-        flickrURL: "https://www.flickr.com/photos/listingslab/54528014218",
-        title: "Trucks",
-        description: "Big boys camping",
-        time: 0,
-        meta: "tags etc",
-        lat: 0,
-        lng: 0,
-        sizes: {
-            orig: {
-                src: "https://",
-                width: 1200,
-                height: 620
-            },
-        }
-      }
-    ],
+    endpoint: `${apibase}/flickr?album=123456789`,
+    album,
+    status,
+    message,
+    result,
   });
 }

--- a/app/api/gl-api/flickr/route.ts
+++ b/app/api/gl-api/flickr/route.ts
@@ -1,9 +1,10 @@
 // core/app/api/gl-api/flickr/route.ts
 import config from '../config.json';
+import { TFlickrPhoto } from './types';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
-  const { apibase /* app */ } = config;
+  const { apibase } = config;
 
   return NextResponse.json({
     time: Date.now(),

--- a/app/api/gl-api/flickr/route.ts
+++ b/app/api/gl-api/flickr/route.ts
@@ -1,15 +1,82 @@
 // core/app/api/gl-api/flickr/route.ts
 import config from '../config.json';
-import { TFlickrPhoto } from './types';
 import { NextRequest, NextResponse } from 'next/server';
+
+
+export type TFlickrPhoto = {
+  id: string;
+  flickrId: string;
+  flickrUrl: string;
+  title?: string;
+  description?: string;
+  lat?: number | null;
+  lng?: number | null;
+  time?: number;
+  meta?: any;
+  sizes?: {
+    orig?: {
+      src: string;
+      width: number;
+      height: number;
+    };
+    small?: {
+      src: string;
+      width: number;
+      height: number;
+    };
+    medium?: {
+      src: string;
+      width: number;
+      height: number;
+    };
+    large?: {
+      src: string;
+      width: number;
+      height: number;
+    };
+  };
+};
 
 export async function GET(request: NextRequest) {
   const { apibase } = config;
+  const description = 'Retrieves list of Flickr Photos in an album by album id';
+  
+  let error = false;
+  let message = "All Good";
+
+  if (error){
+    return NextResponse.json({
+    time: Date.now(),
+    endpoint: `${apibase}/flickr`,
+    description,
+    status: 'error',
+    message,
+  });
+  }
 
   return NextResponse.json({
     time: Date.now(),
     endpoint: `${apibase}/flickr`,
-    description: 'Interacts with Flickr API',
-    // verbs: ['GET'],
+    description,
+    status: 'success',
+    result: [
+      {
+        flickrId: "54528014218",
+        flickrURL: "https://www.flickr.com/photos/listingslab/54528014218",
+        title: "Trucks",
+        description: "Big boys camping",
+        time: 0,
+        meta: "tags etc",
+        lat: 0,
+        lng: 0,
+        sizes: {
+            orig: {
+                src: "https://",
+                width: 1200,
+                height: 620
+            },
+        }
+      }
+    ],
   });
 }

--- a/app/api/gl-api/flickr/route.ts
+++ b/app/api/gl-api/flickr/route.ts
@@ -37,7 +37,8 @@ export async function GET(request: NextRequest) {
       time: Date.now(),
       endpoint: `${apibase}/flickr`,
       status: 'warning',
-      message: 'You need to specify a flickr album id in the query string like this ?album=7210000000',
+      message:
+        'You need to specify a valid flickr album id in the query string like this ?album=72177720324245676',
     });
   }
 
@@ -51,7 +52,6 @@ export async function GET(request: NextRequest) {
     }
 
     // TODO: Call Flickr API here
-
   } catch (err: any) {
     status = 'warning';
     message = err.message || 'Unknown error during Flickr album lookup.';
@@ -65,28 +65,12 @@ export async function GET(request: NextRequest) {
   }
 
   const result: TFlickrPhoto[] = [
-    {
-      flickrId: '54528014218',
-      flickrUrl: 'https://www.flickr.com/photos/listingslab/54528014218',
-      title: 'Trucks',
-      description: 'Big boys camping',
-      time: Date.now(),
-      lat: 0,
-      lng: 0,
-      meta: { tags: ['camping', 'trucks'] },
-      sizes: {
-        orig: {
-          src: 'https://live.staticflickr.com/.../54528014218_o.jpg',
-          width: 1200,
-          height: 620,
-        },
-      },
-    },
+
   ];
 
   return NextResponse.json({
     time: Date.now(),
-    endpoint: `${apibase}/flickr?album=123456789`,
+    endpoint: `${apibase}/flickr?album=${album}`,
     album,
     status,
     message,

--- a/app/api/gl-api/flickr/testData.ts
+++ b/app/api/gl-api/flickr/testData.ts
@@ -1,0 +1,20 @@
+export const testData = {
+  flickrId: '54528014218',
+  flickrUrl: 'https://www.flickr.com/photos/listingslab/54528014218',
+  title: 'Trucks',
+  description: 'Big boys camping',
+  time: Date.now(),
+  lat: 0,
+  lng: 0,
+  meta: { tags: [
+    'camping', 
+    'trucks'
+  ] },
+  sizes: {
+  orig: {
+    src: 'https://live.staticflickr.com/.../54528014218_o.jpg',
+    width: 1200,
+    height: 620,
+  },
+},
+}

--- a/app/api/gl-api/flickr/types.d.ts
+++ b/app/api/gl-api/flickr/types.d.ts
@@ -1,10 +1,33 @@
-export type TPhoto = {
-    id: string;
-    sizes?: {
-        orig: {
-            src: string;
-            width: number;
-            height: number;
-        }
-    }
-}
+export type TFlickrPhoto = {
+  id: string;
+  flickrId: string;
+  flickrUrl: string;
+  title?: string;
+  description?: string;
+  lat?: number | null;
+  lng?: number | null;
+  time?: number;
+  meta?: any;
+  sizes?: {
+    orig?: {
+      src: string;
+      width: number;
+      height: number;
+    };
+    small?: {
+      src: string;
+      width: number;
+      height: number;
+    };
+    medium?: {
+      src: string;
+      width: number;
+      height: number;
+    };
+    large?: {
+      src: string;
+      width: number;
+      height: number;
+    };
+  };
+};

--- a/app/api/gl-api/flickr/types.d.ts
+++ b/app/api/gl-api/flickr/types.d.ts
@@ -1,0 +1,10 @@
+export type TPhoto = {
+    id: string;
+    sizes?: {
+        orig: {
+            src: string;
+            width: number;
+            height: number;
+        }
+    }
+}

--- a/app/api/gl-api/route.tsx
+++ b/app/api/gl-api/route.tsx
@@ -15,7 +15,7 @@ export async function GET() {
     // apibase,
     endpoints: [
       {
-        flickr: 'http://localhost:3000/api/gl-api/flickr',
+        flickr: 'http://localhost:3000/api/gl-api/flickr/?album=7210000000',
       },
       {
         openai: 'http://localhost:3000/api/gl-api/openai',

--- a/public/globalNav.json
+++ b/public/globalNav.json
@@ -34,7 +34,7 @@
       "NextJS",
       "Headless CMS"
     ],
-    "excerpt": "Building and shipping modern web apps for clients who need real results — fast\n\n Small team. Big output\n Real deployments from Day One\n Readable, extensible, Open Source codebases\n\n Discover Goldlabel",
+    "excerpt": "Building and shipping modern web apps for clients who need real results — fast\n\n Small team. Big output\n Real deployments from Day One\n Readable, extensible, Open Source codebases",
     "children": [
       {
         "title": "Free & Open Source",
@@ -51,7 +51,10 @@
             "order": 10,
             "icon": "github",
             "type": "file",
-            "tags": ["free", "core"],
+            "tags": [
+              "free",
+              "core"
+            ],
             "excerpt": "Goldlabel Core is a project designed to deliver powerful, userfriendly web applications that enhance productivity and streamline tasks. The project uses a monorepo architecture with multiple Next.js a"
           },
           {
@@ -76,7 +79,12 @@
             "order": 130,
             "icon": "bouncer",
             "type": "file",
-            "tags": ["cartridges", "cartridge", "free", "bouncer"],
+            "tags": [
+              "cartridges",
+              "cartridge",
+              "free",
+              "bouncer"
+            ],
             "excerpt": "Bouncer is the name of our authentication and access control system built on Firebase Authentication and Firestore. It is included in the Core as a reusable component, available globally from any cart"
           }
         ]
@@ -112,7 +120,11 @@
             "order": 2,
             "icon": "goldlabel",
             "type": "file",
-            "tags": ["CV", "jobs", "work"],
+            "tags": [
+              "CV",
+              "jobs",
+              "work"
+            ],
             "excerpt": "Chris Dorward\n\n Fullstack JavaScript Developer\n\n +44 07745 763 122  \n |  |\n\n\n Summary\n\nOver 20 years of experience delivering scalable web applications across startups, enterprises, and remotefirst te"
           },
           {
@@ -130,7 +142,10 @@
                 "order": 250,
                 "icon": "work",
                 "type": "file",
-                "tags": ["remote", "hybrid"],
+                "tags": [
+                  "remote",
+                  "hybrid"
+                ],
                 "excerpt": "Corporate attitudes to remote working have changed dramatically in recent years.\n\nMany businesses were hesitant to allow employees to work remotely, citing concerns about productivity, communication, "
               },
               {
@@ -139,7 +154,13 @@
                 "order": 555,
                 "icon": "account",
                 "type": "file",
-                "tags": ["cookies", "gdpr", "privacy", "terms", "trust"],
+                "tags": [
+                  "cookies",
+                  "gdpr",
+                  "privacy",
+                  "terms",
+                  "trust"
+                ],
                 "excerpt": "We don't use cookies\n\nWhile cookies have been a fundamental part of web development for many years and continue to serve important functions, there are some considerations that might lead developers t"
               }
             ]
@@ -151,7 +172,10 @@
             "order": 10,
             "icon": "github",
             "type": "folder",
-            "tags": ["github", "process"],
+            "tags": [
+              "github",
+              "process"
+            ],
             "excerpt": "We use GitHub for everything. Including . Most of the communication done between us and our clients during development is done through GitHub in the form of comments, pull resuests, reviews and so for",
             "children": []
           },
@@ -162,7 +186,9 @@
             "order": 10,
             "icon": "private",
             "type": "folder",
-            "tags": ["private"],
+            "tags": [
+              "private"
+            ],
             "excerpt": "This page requires a higher level of access",
             "children": []
           },

--- a/public/globalNav.json
+++ b/public/globalNav.json
@@ -51,10 +51,7 @@
             "order": 10,
             "icon": "github",
             "type": "file",
-            "tags": [
-              "free",
-              "core"
-            ],
+            "tags": ["free", "core"],
             "excerpt": "Goldlabel Core is a project designed to deliver powerful, userfriendly web applications that enhance productivity and streamline tasks. The project uses a monorepo architecture with multiple Next.js a"
           },
           {
@@ -79,12 +76,7 @@
             "order": 130,
             "icon": "bouncer",
             "type": "file",
-            "tags": [
-              "cartridges",
-              "cartridge",
-              "free",
-              "bouncer"
-            ],
+            "tags": ["cartridges", "cartridge", "free", "bouncer"],
             "excerpt": "Bouncer is the name of our authentication and access control system built on Firebase Authentication and Firestore. It is included in the Core as a reusable component, available globally from any cart"
           }
         ]
@@ -120,11 +112,7 @@
             "order": 2,
             "icon": "goldlabel",
             "type": "file",
-            "tags": [
-              "CV",
-              "jobs",
-              "work"
-            ],
+            "tags": ["CV", "jobs", "work"],
             "excerpt": "Chris Dorward\n\n Fullstack JavaScript Developer\n\n +44 07745 763 122  \n |  |\n\n\n Summary\n\nOver 20 years of experience delivering scalable web applications across startups, enterprises, and remotefirst te"
           },
           {
@@ -142,10 +130,7 @@
                 "order": 250,
                 "icon": "work",
                 "type": "file",
-                "tags": [
-                  "remote",
-                  "hybrid"
-                ],
+                "tags": ["remote", "hybrid"],
                 "excerpt": "Corporate attitudes to remote working have changed dramatically in recent years.\n\nMany businesses were hesitant to allow employees to work remotely, citing concerns about productivity, communication, "
               },
               {
@@ -154,13 +139,7 @@
                 "order": 555,
                 "icon": "account",
                 "type": "file",
-                "tags": [
-                  "cookies",
-                  "gdpr",
-                  "privacy",
-                  "terms",
-                  "trust"
-                ],
+                "tags": ["cookies", "gdpr", "privacy", "terms", "trust"],
                 "excerpt": "We don't use cookies\n\nWhile cookies have been a fundamental part of web development for many years and continue to serve important functions, there are some considerations that might lead developers t"
               }
             ]
@@ -172,10 +151,7 @@
             "order": 10,
             "icon": "github",
             "type": "folder",
-            "tags": [
-              "github",
-              "process"
-            ],
+            "tags": ["github", "process"],
             "excerpt": "We use GitHub for everything. Including . Most of the communication done between us and our clients during development is done through GitHub in the form of comments, pull resuests, reviews and so for",
             "children": []
           },
@@ -186,9 +162,7 @@
             "order": 10,
             "icon": "private",
             "type": "folder",
-            "tags": [
-              "private"
-            ],
+            "tags": ["private"],
             "excerpt": "This page requires a higher level of access",
             "children": []
           },

--- a/public/globalNav.json
+++ b/public/globalNav.json
@@ -34,7 +34,7 @@
       "NextJS",
       "Headless CMS"
     ],
-    "excerpt": "Building and shipping modern web apps for clients who need real results — fast\n\n Small team. Big output\n Real deployments from Day One\n Readable, extensible, Open Source codebases",
+    "excerpt": "We build and shipp modern web apps for clients who need real results — fast\n\n Small team. Big output\n Real deployments from Day One\n Readable, extensible, Open Source codebases",
     "children": [
       {
         "title": "Free & Open Source",

--- a/public/globalNav.json
+++ b/public/globalNav.json
@@ -176,7 +176,7 @@
               "github",
               "process"
             ],
-            "excerpt": "We use GitHub for everything. Including project management. Most of the communication done between us and our clients during development is done through GitHub in the form of comments, pull resuests, ",
+            "excerpt": "We use GitHub for everything. Including . Most of the communication done between us and our clients during development is done through GitHub in the form of comments, pull resuests, reviews and so for",
             "children": []
           },
           {

--- a/public/markdown/index.md
+++ b/public/markdown/index.md
@@ -8,6 +8,10 @@ image: /png/defaultFeatured.png
 github: https://github.com/javascript-pro/core
 tags: JavaScript, Next Gen, Next.js, core, Gen X, goldlabel, pr0, bouncer, AI Prompt Engineering, ChatGPT, OpenAI, Singularity, Frontend, Vanilla JS, TypeScript, React, Angular, Vue, Material UI, MUI, Flash, Server Side JavaScript, Node, Gatsby, NextJS, Headless CMS
 ---
+- [About](/work/company)
+- [GitHub](/work/github)
+- [Photos](/balance/photos)
+- [Flash](/free/flash)
 
 ## Building and shipping modern web apps for clients who need real results — fast
 
@@ -15,8 +19,5 @@ tags: JavaScript, Next Gen, Next.js, core, Gen X, goldlabel, pr0, bouncer, AI Pr
 - Real deployments from Day One
 - Readable, extensible, Open Source codebases
 
-## Discover Goldlabel
 
-- [About](/work/company)
-- [Photos](/balance/photos)
-- [Flash](/free/flash)
+

--- a/public/markdown/index.md
+++ b/public/markdown/index.md
@@ -8,6 +8,7 @@ image: /png/defaultFeatured.png
 github: https://github.com/javascript-pro/core
 tags: JavaScript, Next Gen, Next.js, core, Gen X, goldlabel, pr0, bouncer, AI Prompt Engineering, ChatGPT, OpenAI, Singularity, Frontend, Vanilla JS, TypeScript, React, Angular, Vue, Material UI, MUI, Flash, Server Side JavaScript, Node, Gatsby, NextJS, Headless CMS
 ---
+
 - [About](/work/company)
 - [GitHub](/work/github)
 - [Photos](/balance/photos)
@@ -18,6 +19,3 @@ tags: JavaScript, Next Gen, Next.js, core, Gen X, goldlabel, pr0, bouncer, AI Pr
 - _Small_ team. _Big_ output
 - Real deployments from Day One
 - Readable, extensible, Open Source codebases
-
-
-

--- a/public/markdown/index.md
+++ b/public/markdown/index.md
@@ -5,16 +5,15 @@ title: Goldlabel pr0
 description: Custom software that works
 icon: blokey
 image: /png/defaultFeatured.png
-github: https://github.com/javascript-pro/core
+github: https://github.com/javascript-pro/core/issues/76
 tags: JavaScript, Next Gen, Next.js, core, Gen X, goldlabel, pr0, bouncer, AI Prompt Engineering, ChatGPT, OpenAI, Singularity, Frontend, Vanilla JS, TypeScript, React, Angular, Vue, Material UI, MUI, Flash, Server Side JavaScript, Node, Gatsby, NextJS, Headless CMS
 ---
 
 - [About](/work/company)
 - [GitHub](/work/github)
-- [Photos](/balance/photos)
 - [Flash](/free/flash)
 
-## Building and shipping modern web apps for clients who need real results — fast
+## We build and shipp modern web apps for clients who need real results — fast
 
 - _Small_ team. _Big_ output
 - Real deployments from Day One

--- a/public/markdown/work/company/index.md
+++ b/public/markdown/work/company/index.md
@@ -5,6 +5,7 @@ description: About Goldlabel Apps Ltd
 slug: /work/company
 icon: work
 image: /png/defaultFeatured.png
+github: https://github.com/javascript-pro/core/issues/76
 ---
 
 > Goldlabel Apps Ltd is a UK Limited Company (5460545)

--- a/public/markdown/work/company/privacy-cookies.md
+++ b/public/markdown/work/company/privacy-cookies.md
@@ -6,6 +6,7 @@ slug: /work/company/privacy-cookies
 icon: account
 image: /png/defaultFeatured.png
 tags: cookies, gdpr, privacy, terms, trust
+github: https://github.com/javascript-pro/core/issues/76
 ---
 
 > We don't use cookies

--- a/public/markdown/work/company/remote-working.md
+++ b/public/markdown/work/company/remote-working.md
@@ -6,6 +6,7 @@ slug: /work/company/remote-working
 icon: work
 image: /png/defaultFeatured.png
 tags: remote, hybrid
+github: https://github.com/javascript-pro/core/issues/76
 ---
 
 > Corporate attitudes to remote working have changed dramatically in recent years.

--- a/public/markdown/work/github/index.md
+++ b/public/markdown/work/github/index.md
@@ -6,6 +6,52 @@ slug: /work/github
 icon: github
 image: /png/javascript.png
 tags: github, process
+github: https://github.com/javascript-pro/core/issues/76
 ---
 
-We use GitHub for everything. Including project management. Most of the communication done between us and our clients during development is done through GitHub in the form of comments, pull resuests, reviews and so forth
+We use GitHub for everything. Including [project management](https://github.com/javascript-pro/core/issues/76). Most of the communication done between us and our clients during development is done through GitHub in the form of comments, pull resuests, reviews and so forth
+
+A typical JSON Object might describe a Photo shown from the Flickr service
+
+
+
+```javascript
+{
+    id={"xxxx-yyyy-zzzz"}
+    flickrId="54528014218" // Flickr's id
+    flickrURL="https://www.flickr.com/photos/listingslab/54528014218" // vital
+    title="trucks", // If any
+    description="big boys camping", // If any
+    time=100000000 // Unix epoh
+    meta="tags, etc"
+    lat={0}
+    lng={0}
+    sizes={
+        orig: {
+            src="https://" // use flickr as CDN
+            width={1200}
+            height={620}
+        },
+        small: {
+            src="https://" // use flickr as CDN
+            width={300}
+            height={115}
+        }
+    }
+}
+```
+
+
+
+```typescript
+export type TPhoto = {
+    id: string;
+    sizes?: {
+        orig: {
+            src: string;
+            width: number;
+            height: nbumber;
+        }
+    }
+}
+```

--- a/public/markdown/work/github/index.md
+++ b/public/markdown/work/github/index.md
@@ -38,16 +38,3 @@ A typical JSON Object might describe a Photo shown from the Flickr service
     }
 }
 ```
-
-```typescript
-export type TPhoto = {
-  id: string;
-  sizes?: {
-    orig: {
-      src: string;
-      width: number;
-      height: nbumber;
-    };
-  };
-};
-```

--- a/public/markdown/work/github/index.md
+++ b/public/markdown/work/github/index.md
@@ -13,8 +13,6 @@ We use GitHub for everything. Including [project management](https://github.com/
 
 A typical JSON Object might describe a Photo shown from the Flickr service
 
-
-
 ```javascript
 {
     id={"xxxx-yyyy-zzzz"}
@@ -41,17 +39,15 @@ A typical JSON Object might describe a Photo shown from the Flickr service
 }
 ```
 
-
-
 ```typescript
 export type TPhoto = {
-    id: string;
-    sizes?: {
-        orig: {
-            src: string;
-            width: number;
-            height: nbumber;
-        }
-    }
-}
+  id: string;
+  sizes?: {
+    orig: {
+      src: string;
+      width: number;
+      height: nbumber;
+    };
+  };
+};
 ```

--- a/public/markdown/work/index.md
+++ b/public/markdown/work/index.md
@@ -5,6 +5,7 @@ description: Professional Fullstack JavaScript Development
 slug: /work
 icon: work
 image: /png/javascript.png
+github: https://github.com/javascript-pro/core/issues/76
 tags: JavaScript, Vanilla JavaScript, TypeScript, React, Angular, Vue, etc, Material UI, Flash, Server Side JavaScript, Node, Gatsby, NextJS, Headless CMS
 ---
 

--- a/public/markdown/work/javascript/index.md
+++ b/public/markdown/work/javascript/index.md
@@ -5,5 +5,6 @@ description: ECMA Script
 slug: /work/javascript
 icon: javascript
 image: /png/javascript.png
+github: https://github.com/javascript-pro/core/issues/76
 tags: JavaScript, Vanilla JavaScript, TypeScript, React, Angular, Vue, Material UI, Flash, Server Side JavaScript, Node, Gatsby, NextJS, Headless CMS, JSON
 ---

--- a/public/markdown/work/private/index.md
+++ b/public/markdown/work/private/index.md
@@ -7,6 +7,7 @@ icon: private
 image: /png/defaultFeatured.png
 tags: private
 private: true
+github: https://github.com/javascript-pro/core/issues/76
 ---
 
 ## This page requires a higher level of access

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,1 @@
+FIREBASE_PROJECT_ID="goldlabelpro"


### PR DESCRIPTION
Adds an API endpoint to retrieve and display photos from a specified Flickr album.

- Implements a new `/api/gl-api/flickr` endpoint that fetches data from the Flickr API based on the provided album ID.
- Includes error handling and validation for missing API credentials and album ID.
- Defines TypeScript types for Flickr photo data.
- Updates markdown files to link to issue #76.

Fixes #76